### PR TITLE
Update installation instructions

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -205,7 +205,7 @@ Running the NIST Competitor
 
     .. code-block:: sh
 
-      ros2 launch ariac_gazebo ariac.launch.py dev_mode:=true trial_name:=kitting
+      ros2 launch ariac_gazebo ariac.launch.py dev_mode:=true trial_name:=kitting competitor_pkg:=nist_competitor
 
     **Terminal 2:** Launch the move_group node
 


### PR DESCRIPTION
Adding "competitor_pkg:=nist_competitor" to the Terminal 1 command for Running NIST Competitor