### PR TITLE
Update rosdep install command in installation steps

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -41,7 +41,7 @@ Configuring the ARIAC Environment
 
   .. code-block:: sh
 
-    sudo apt install python3-rosdep
+    sudo apt update && sudo apt install python3-rosdep
 
 5. Initialize rosdep
 


### PR DESCRIPTION
Update the apt package index at some point before installing ARIAC dependencies.

`rosdep install` command at Step 6 fails without updating the package index because some ROS packages that install using apt Ex: `sudo apt install ros-iron-package-name` might not be found.